### PR TITLE
Update crosswalk release urls

### DIFF
--- a/bin/crosswalk-cordova-android
+++ b/bin/crosswalk-cordova-android
@@ -21,9 +21,9 @@ var Runtime = {
 	 * We must pressure crosswalk-project.org to offer a 'latest-release' url for each release channel
 	 */
 	ReleaseChannels: {
-		stable: 'https://download.01.org/crosswalk/releases/crosswalk/android/stable/10.39.235.15/crosswalk-10.39.235.15.zip',
-		beta: 'https://download.01.org/crosswalk/releases/crosswalk/android/beta/11.40.277.1/crosswalk-11.40.277.1.zip',
-		canary: 'https://download.01.org/crosswalk/releases/crosswalk/android/canary/12.40.278.0/crosswalk-12.40.278.0.zip'
+		stable: 'https://download.01.org/crosswalk/releases/crosswalk/android/stable/10.39.235.15/arm/crosswalk-cordova-10.39.235.15-arm.zip',
+		beta: 'https://download.01.org/crosswalk/releases/crosswalk/android/beta/11.40.277.1/arm/crosswalk-cordova-11.40.277.1-arm.zip',
+		canary: 'https://download.01.org/crosswalk/releases/crosswalk/android/canary/12.40.278.0/arm/crosswalk-cordova-12.40.278.0-arm.zip'
 	},
 
 	/**

--- a/bin/crosswalk-cordova-android
+++ b/bin/crosswalk-cordova-android
@@ -21,9 +21,9 @@ var Runtime = {
 	 * We must pressure crosswalk-project.org to offer a 'latest-release' url for each release channel
 	 */
 	ReleaseChannels: {
-		stable: 'https://download.01.org/crosswalk/releases/crosswalk/android/stable/8.37.189.12/arm/crosswalk-cordova-8.37.189.12-arm.zip',
-		beta: 'https://download.01.org/crosswalk/releases/crosswalk/android/beta/10.39.235.8/arm/crosswalk-cordova-10.39.235.8-arm.zip',
-		canary: 'https://download.01.org/crosswalk/releases/crosswalk/android/canary/11.39.251.0/arm/crosswalk-cordova-11.39.251.0-arm.zip'
+		stable: 'https://download.01.org/crosswalk/releases/crosswalk/android/stable/10.39.235.15/crosswalk-10.39.235.15.zip',
+		beta: 'https://download.01.org/crosswalk/releases/crosswalk/android/beta/11.40.277.1/crosswalk-11.40.277.1.zip',
+		canary: 'https://download.01.org/crosswalk/releases/crosswalk/android/canary/12.40.278.0/crosswalk-12.40.278.0.zip'
 	},
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crosswalk-cordova-android",
   "description": "Automagically migrates your Cordova Android projects so they use Crosswalks Chromium webview.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/confused-pv/crosswalk-cordova-android",
   "author": {
     "name": "Prakhar Verma"


### PR DESCRIPTION
Hi, have just bumped up the release versions (looks like the beta is now the stable version) and the package minor version.  Is this ok?
